### PR TITLE
Fixing bug the hide first paragraph of text when ad blocker is on

### DIFF
--- a/resources/assets/dfp.js
+++ b/resources/assets/dfp.js
@@ -203,7 +203,11 @@ googletag.cmd = googletag.cmd || [];
 
   function checkAdSlotIsPopulated($advertSlot) {
     if ($advertSlot.children('div:first-child').is(':visible') === false) {
-      $advertSlot.parent().addClass('advert-failed')
+      if ($advertSlot.hasClass('advert-container--type-vertical--paragraph') === true) {
+        $advertSlot.addClass('advert-failed')
+      }else {
+        $advertSlot.parent().addClass('advert-failed')
+      }
       console.log('AgreableAdPlugin: slot failed to render')
       setTimeout(checkAdSlotIsPopulated.bind(this, $advertSlot), 300)
     }


### PR DESCRIPTION
This is a fix that allows the first paragraph of an article to be visible if an ad blocker tool is enabled
